### PR TITLE
Added tests for cluster HTTP connections using a custom HTTPClusterConfig instance

### DIFF
--- a/test/clojurewerkz/welle/test/core_test.clj
+++ b/test/clojurewerkz/welle/test/core_test.clj
@@ -1,5 +1,6 @@
 (ns clojurewerkz.welle.test.core-test
-  (:import com.basho.riak.client.raw.RawClient)
+  (:import com.basho.riak.client.raw.RawClient
+           [com.basho.riak.client.raw.http HTTPClientConfig$Builder HTTPClusterConfig])
   (:require [clojurewerkz.welle.core :as wc])
   (:use clojure.test))
 
@@ -36,6 +37,17 @@
       (wc/ping client)
       (wc/shutdown client))))
 
+(deftest connect-using-clustered-http-client-with-config-instance
+  (let [config (doto (HTTPClusterConfig. wc/default-cluster-connection-limit)
+                 (.addClient (-> (HTTPClientConfig$Builder.)
+                                 (.withUrl "http://127.0.0.1:8098/riak")
+                                 (.build))))
+        ^RawClient client (wc/connect-to-cluster config)]
+    (dotimes [x 10]
+      (.ping client)
+      (wc/ping)
+      (wc/shutdown))))
+
 (deftest connect-using-clustered-http-client-and-default-client
   (wc/connect-to-cluster! ["http://127.0.0.1:8098/riak"
                            "http://localhost:8098/riak"])
@@ -51,3 +63,14 @@
     (.ping ^RawClient wc/*riak-client*)
     (wc/ping)
     (wc/shutdown)))
+
+(deftest connect-using-clustered-http-client-and-default-client-with-config-instance
+  (let [config (doto (HTTPClusterConfig. wc/default-cluster-connection-limit)
+                 (.addClient (-> (HTTPClientConfig$Builder.)
+                                 (.withUrl "http://127.0.0.1:8098/riak")
+                                 (.build))))]
+    (wc/connect-to-cluster! config)
+    (dotimes [x 10]
+      (.ping ^RawClient wc/*riak-client*)
+      (wc/ping)
+      (wc/shutdown))))


### PR DESCRIPTION
Sorry about the multiple commits for the same change but I realized that I didn't write any tests for when the user passes an instance of HTTPClusterConfig.  This commit resolves that.
