### PR TITLE
Using doall after calling pmap to ensure the lazy seq is realized

### DIFF
--- a/src/clojure/clojurewerkz/welle/kv.clj
+++ b/src/clojure/clojurewerkz/welle/kv.clj
@@ -106,13 +106,13 @@
    operations is a problem. For deleting a very large number of keys (say, thousands), consider using
    map/reduce"
   ([^String bucket-name keys]
-     (pmap (fn [^String k]
-             (delete bucket-name k))
-           keys))
+     (doall (pmap (fn [^String k]
+                    (delete bucket-name k))
+                  keys)))
   ([^String bucket-name keys & rest]
-     (pmap (fn [^String k]
-             (apply delete (concat [bucket-name k] rest)))
-           keys)))
+     (doall (pmap (fn [^String k]
+                    (apply delete (concat [bucket-name k] rest)))
+                  keys))))
 
 
 (defn delete-all-via-2i

--- a/test/clojurewerkz/welle/test/kv_test.clj
+++ b/test/clojurewerkz/welle/test/kv_test.clj
@@ -253,3 +253,21 @@
     (is (kv/fetch-one bucket-name k))
     (kv/delete bucket-name k :rw 2)
     (is (nil? (kv/fetch-one bucket-name k :r 2)))))
+
+
+(deftest test-fetching-multiple-deleted-values-with-bucket-settings
+  (let [bucket-name "clojurewerkz.welle.kv5"
+        bucket      (wb/update bucket-name)
+        key         "delete-me"
+        value       "another value"
+        key-values  (map (fn [i] [(str key i) (str value i)]) (range 10))]
+    (drain bucket-name)
+    (Thread/sleep 150)
+
+    (doseq [[k v] key-values]
+      (is (nil? (kv/fetch-one bucket-name k)))
+      (kv/store bucket-name k v)
+      (is (kv/fetch-one bucket-name k)))
+    (kv/delete-all bucket-name (map first key-values))
+    (doseq [[k v] key-values]
+      (is (nil? (kv/fetch-one bucket-name k))))))


### PR DESCRIPTION
I am using Clojure 1.4.0 and I noticed that the delete-all function would not delete all the keys.
