### PR TITLE
don't always convert json keys to keywords

### DIFF
--- a/src/clojure/clojurewerkz/welle/conversion.clj
+++ b/src/clojure/clojurewerkz/welle/conversion.clj
@@ -27,6 +27,8 @@
 (def ^{:doc "Type object for a Java primitive byte array."}
   byte-array-type (class (make-array Byte/TYPE 0)))
 
+(def ^:dynamic ^java.lang.Boolean *convert-json-keys-to-keywords* true)
+
 
 ;;
 ;; API
@@ -338,21 +340,21 @@
 ;; JSON
 (defmethod deserialize Constants/CTYPE_JSON
   [value _]
-  (json/parse-string (String. ^bytes value) true))
+  (json/parse-string (String. ^bytes value) *convert-json-keys-to-keywords*))
 ;; as of Riak Java client 1.1, this constant's value is "application/json;charset=UTF-8"
 ;; (no space between base content type and parameters). However, Riak returns content type *with*
 ;; the space so we have to cover both. Reported to Basho at https://github.com/basho/riak-java-client/issues/125.
 ;; MK.
 (defmethod deserialize Constants/CTYPE_JSON_UTF8
   [value _]
-  (json/decode (String. ^bytes value "UTF-8") true))
+  (json/decode (String. ^bytes value "UTF-8") *convert-json-keys-to-keywords*))
 (defmethod deserialize "application/json; charset=UTF-8"
   [value _]
-  (json/decode (String. ^bytes value "UTF-8") true))
+  (json/decode (String. ^bytes value "UTF-8") *convert-json-keys-to-keywords*))
 (defmethod deserialize "application/json+gzip"
   [value _]
   (with-open [in (GZIPInputStream. (ByteArrayInputStream. ^bytes value))]
-    (json/decode-stream (InputStreamReader. in "UTF-8") true)))
+    (json/decode-stream (InputStreamReader. in "UTF-8") *convert-json-keys-to-keywords*)))
 
 ;; SMILE (binary JSON)
 (defmethod deserialize "application/jackson-smile"


### PR DESCRIPTION
When welle deserializes json, it passes true into cheshire so that cheshire converts all keys from json maps into keywords in clojure. This can have some unexpected space problems for your jvm process, because keywords are never garbage collected.

My rough draft just adds a variable set with (binding) to the conversion namespace that is by default bound to true (because that doesn't break backwards compatability), but can be rebound by the user.

Thoughts? I didn't want to make this a variable you pass into each of the kv functions, as it seemed like they have enough arguments already.

The current workaround for this is to do your own deserialization, but that's somewhat cumbersome.

As discussed in https://github.com/michaelklishin/welle/issues/10
