### PR TITLE
Java 8 will throw an ClassNotFoundException on private static inner clas...

### DIFF
--- a/src/clojure/clojurewerkz/welle/conversion.clj
+++ b/src/clojure/clojurewerkz/welle/conversion.clj
@@ -187,7 +187,7 @@
   [^IRiakObject ro]
   (let [indexes (concat (seq (.allBinIndexes ro))
                         (seq (.allIntIndexes ro)))
-        step    (fn [acc-m ^java.util.HashMap$Entry idx]
+        step    (fn [acc-m ^java.util.Map$Entry idx]
                   (let [idx-name   (keyword (.getName ^RiakIndex (.getKey idx)))
                         idx-fields (set ^java.util.Set (.getValue idx))]
                     (merge-with cs/union acc-m {idx-name idx-fields})))]


### PR DESCRIPTION
...ses like java.util.HashMap$Entry. Solution is to reference java.util.Map$Entry instead, which is public.
