### PR TITLE
default serializer added

### DIFF
--- a/src/clojure/clojurewerkz/welle/conversion.clj
+++ b/src/clojure/clojurewerkz/welle/conversion.clj
@@ -333,7 +333,9 @@
   (binding [*print-dup* true]
     (pr-str value)))
 
-
+(defmethod serialize :default
+  [value _]
+  (to-bytes value))
 
 (defmulti deserialize (fn [_ content-type]
                         content-type))


### PR DESCRIPTION
non-standard content-types like “image/png” are handled correctly now.