### PR TITLE
Fix Clojure Deserialization

### DIFF
--- a/src/clojure/clojurewerkz/welle/conversion.clj
+++ b/src/clojure/clojurewerkz/welle/conversion.clj
@@ -383,8 +383,7 @@
 ;; Clojure
 (defmethod deserialize "application/clojure"
   [value _]
-  (binding [*print-dup* true]
-    (read-string (String. ^bytes value))))
+  (read-string (String. ^bytes value "UTF-8")))
 
 
 (defmethod deserialize :default


### PR DESCRIPTION
First, setting of *print-dup* has no meaning while reading. Second
because strings are encoded always as UTF-8 by the Riak client, they
should be read back explicitly with UTF-8.